### PR TITLE
Fix typo in clock calendar in config.jsonc

### DIFF
--- a/waybar-theme/config.jsonc
+++ b/waybar-theme/config.jsonc
@@ -101,7 +101,7 @@
       "mode-mon-col": 3,
       "on-click-right": "mode",
       "format": {
-        "mouth": "<span color='#e5c890'><b>{}</b></span>",
+        "months": "<span color='#e5c890'><b>{}</b></span>",
         "weekdays": "<span color='#ca9ee6'><b>{}</b></span>",
         "today": "<span color='#f4b8e4'><b>{}</b></span>"
       }


### PR DESCRIPTION
Fixed typo in the calendar format of the clock module. It had "mouth" instead of "months"