### PR TITLE
remove box-shadow when window is empty

### DIFF
--- a/waybar-theme/style.css
+++ b/waybar-theme/style.css
@@ -41,6 +41,7 @@ window#waybar.empty #window {
   color: transparent;
   padding: 0;
   margin: 0;
+  box-shadow: none;
 }
 #waybar.empty .modules-center {
   opacity: 0;


### PR DESCRIPTION
When switching to a new workspace (or when there is no open window), the hyprland/window module was displaying the drop-shadow without the rest of the module.

<img width="278" height="92" alt="image" src="https://github.com/user-attachments/assets/38a7cf0e-6d76-4674-a48e-9a6ad29a36c0" />

I added box-shadow: none to the existing style block for empty windows to override the global box-shadow styling.