### PR TITLE
Restart custom/updatespacman if crashed in waybar config.jsonc

### DIFF
--- a/waybar-theme/config.jsonc
+++ b/waybar-theme/config.jsonc
@@ -55,7 +55,8 @@
       "updated": ""
     },
     "exec-if": "which waybar-module-pacman-updates",
-    "exec": "waybar-module-pacman-updates --no-zero-output"
+    "exec": "waybar-module-pacman-updates --no-zero-output",
+    "restart-interval": 10
   },
    "hyprland/window": {
     "format": "{title} - {class}",


### PR DESCRIPTION
Sometimes when updating packages from the Omarchy update menu, the waybar-module-pacman-updates process will crash. This will keep the previous updates needed count on the waybar and will not refresh until you restart waybar.

Adding "restart-interval": 10 tells waybar to re-execute the process if it crashes after a delay of 10 seconds.