### PR TITLE
Update hyprland.conf to use new windowrule

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -5,8 +5,8 @@ $activeBorderGradient = rgba(e78284ff) rgba(ef9f76ff) rgba(e5c890ff) rgba(a6d189
 $inactiveShadowColor = rgb(000000)
 $activeShadowColor =  rgb(000000)
 
-windowrule = match:class ^brave-youtube\.com__-Default$, opacity 1.0 override
-windowrule = match:class ^chrome-youtube\.com__-Default$, opacity 1.0 override
+windowrule = match:class ^(brave-youtube\\.com__-Default)$, opacity 1.0 override
+windowrule = match:class ^(chrome-youtube\\.com__-Default)$, opacity 1.0 override
 
 general {
     col.active_border = $activeBorderGradient


### PR DESCRIPTION
After this month's omarchy stable updates, hyprland deprecated windowrulev2. This updates the two windowrulev2 lines in hyprland.conf with the new windowrule syntax.